### PR TITLE
Temporary downgrade to plugin 1.3.1

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -46,7 +46,7 @@ dependencies {
 
   compile gradleApi()
   compile localGroovy()
-  compile 'com.android.tools.build:gradle:1.5.0'
+  compile 'com.android.tools.build:gradle:1.3.1'
   compile 'org.rauschig:jarchivelib:0.6.0'
   compile 'commons-io:commons-io:2.4'
 


### PR DESCRIPTION
Temporary downgrade to plugin 1.3.1 beacause of https://groups.google.com/forum/?fromgroups#!topic/adt-dev/uGogKKuuHi8